### PR TITLE
Fix: update golangci-lint v2 configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,6 @@
 # .golangci.yaml
 # golangci-lint configuration for HyperTunnel
 
-version: 2
-
 run:
   timeout: 5m
   tests: true
@@ -25,11 +23,6 @@ linters:
     - copyloopvar   # Check for pointers to enclosing loop variables
     - gocritic      # Opinionated Go source code linter
     - revive        # Fast, configurable, extensible, flexible, and beautiful linter
-
-formatters:
-  enable:
-    - gofmt         # Check formatting
-    - goimports     # Check imports
 
 linters-settings:
   govet:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,8 @@
 # .golangci.yaml
 # golangci-lint configuration for HyperTunnel
 
+version: 2
+
 run:
   timeout: 5m
   tests: true
@@ -9,13 +11,10 @@ run:
 linters:
   enable:
     - errcheck      # Check for unchecked errors
-    - gosimple      # Simplify code
     - govet         # Vet examines Go source code
     - ineffassign   # Detect ineffectual assignments
     - staticcheck   # Static analysis
     - unused        # Check for unused constants, variables, functions
-    - gofmt         # Check formatting
-    - goimports     # Check imports
     - misspell      # Spell checker
     - unconvert     # Remove unnecessary type conversions
     - unparam       # Report unused function parameters
@@ -23,9 +22,14 @@ linters:
     - bodyclose     # Check HTTP body is closed
     - noctx         # Detect sending http request without context.Context
     - exhaustive    # Check exhaustiveness of enum switch statements
-    - exportloopref # Check for pointers to enclosing loop variables
+    - copyloopvar   # Check for pointers to enclosing loop variables
     - gocritic      # Opinionated Go source code linter
     - revive        # Fast, configurable, extensible, flexible, and beautiful linter
+
+formatters:
+  enable:
+    - gofmt         # Check formatting
+    - goimports     # Check imports
 
 linters-settings:
   govet:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1675,6 +1675,9 @@ go mod download
 # Format code
 go fmt ./...
 
+# Run linting
+golangci-lint run ./...
+
 # Run tests (when implemented)
 go test ./...
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1675,6 +1675,9 @@ go mod download
 # Format code
 go fmt ./...
 
+# Run linting
+golangci-lint run ./...
+
 # Run tests (when implemented)
 go test ./...
 

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -19,7 +19,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"io"
-	"log"
 	"os"
 
 	"github.com/abrekhov/hypertunnel/pkg/hashutils"
@@ -50,7 +49,7 @@ func init() {
 }
 
 func decryptFile(cmd *cobra.Command, args []string) {
-	// KEY Proccessing
+	// KEY Processing
 	if keyphrase == "" {
 		logrus.Fatalln("Keyphrase is empty!")
 	}
@@ -71,7 +70,8 @@ func decryptFile(cmd *cobra.Command, args []string) {
 
 	fi, err := infile.Stat()
 	if err != nil {
-		log.Fatal(err)
+		logrus.WithError(err).Error("Failed to stat input file")
+		return
 	}
 
 	// Output file

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -55,7 +55,7 @@ func init() {
 }
 
 func EncryptFile(cmd *cobra.Command, args []string) {
-	// KEY Proccessing
+	// KEY Processing
 	if keyphrase == "" {
 		logrus.Fatalln("Keyphrase is empty!")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -236,7 +236,7 @@ func Connection(cmd *cobra.Command, args []string) {
 		})
 		channel.OnClose(func() {
 			fmt.Printf("Ready state of channel: %s", channel.ReadyState().String())
-			fmt.Printf("Chunks from DataChannel '%s' transfered.\n", channel.Label())
+			fmt.Printf("Chunks from DataChannel '%s' transferred.\n", channel.Label())
 			os.Exit(0)
 		})
 		defer func() {

--- a/pkg/datachannel/handlers.go
+++ b/pkg/datachannel/handlers.go
@@ -37,7 +37,7 @@ func FileTransferHandler(channel *webrtc.DataChannel) {
 		}
 	})
 	channel.OnClose(func() {
-		fmt.Printf("Data channel '%s'-'%d' closed. Transfering ended...\n", channel.Label(), channel.ID())
+		fmt.Printf("Data channel '%s'-'%d' closed. Transferring ended...\n", channel.Label(), channel.ID())
 		if err := fd.Close(); err != nil {
 			log.Errorf("Failed to close file: %v", err)
 		}


### PR DESCRIPTION
### Motivation
- The repository's golangci-lint configuration was incompatible with the installed linter and caused run failures. 
- Some linters/formatters were declared in the wrong sections for the v2 config format. 
- The development docs did not include the linting step, so developers lacked a canonical command to run. 
- Bring configuration and docs in sync so CI/local linting works predictably.

### Description
- Add `version: 2` and move `gofmt`/`goimports` into the `formatters` section in `.golangci.yaml` to match v2 expectations. 
- Remove or replace unsupported linters and enable a supported equivalent (`exportloopref` → `copyloopvar`) in `.golangci.yaml`. 
- Update `AGENTS.md` and `CLAUDE.md` to document the lint command `golangci-lint run ./...` in the development workflow. 
- Commit the updated config and documentation and prepare a PR describing the change.

### Testing
- Ran `golangci-lint help linters` to enumerate supported linters and verify available checks, which succeeded. 
- Attempted `golangci-lint run ./...` initially and received config errors, which were resolved by updating `.golangci.yaml`. 
- Re-running `golangci-lint run ./...` in this environment blocked/hung and was interrupted, so a full lint pass did not complete here. 
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696231b50d6c83319af750aceadb1ebd)