### PR TITLE
Handle existing files on receive and add `--auto-accept` flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,10 +32,11 @@ import (
 
 // Flags
 var (
-	cfgFile string
-	verbose bool
-	isOffer bool
-	file    string
+	cfgFile    string
+	verbose    bool
+	isOffer    bool
+	file       string
+	autoAccept bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -70,6 +71,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.hypertunnel.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Increase verbosity")
 	rootCmd.Flags().StringVarP(&file, "file", "f", "", "File to transfer")
+	rootCmd.Flags().BoolVar(&autoAccept, "auto-accept", false, "Automatically accept incoming files and overwrites")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -96,6 +98,7 @@ func initConfig() {
 }
 
 func Connection(cmd *cobra.Command, args []string) {
+	datachannel.AutoAccept = autoAccept
 
 	// Who receiver and who sender?
 	if file == "" {


### PR DESCRIPTION
### Motivation

- Prevent accidental overwrites when receiving a file by explicitly checking the target file before creating it.  
- Provide deterministic behavior for automated workflows by adding an option to skip interactive prompts.  
- Improve error handling when `os.Stat` fails with unexpected errors instead of treating all cases the same.  
- Align receiver behavior with roadmap Phase 1.4 security expectations (confirmation & overwrite protection). 

### Description

- Replace the simple `os.Stat` check in `pkg/datachannel/handlers.go` with explicit handling: if `err == nil` prompt for overwrite, if `os.IsNotExist(err)` proceed, and if other `err != nil` log and abort.  
- Keep the receive confirmation prompt using `askForConfirmation` but guard both overwrite and receive prompts with a new package-level boolean `AutoAccept`.  
- Add a `--auto-accept` flag in `cmd/root.go` and wire it into the handler via `datachannel.AutoAccept = autoAccept` so automation can bypass prompts.  
- Small code hygiene: use `log.Errorf` for stat failures and avoid creating files when checks fail.  

### Testing

- No automated tests were executed for this change.  
- Code formatting was run with `gofmt` during the rollout (no compile/test run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624c63cd70833186a223a4465d7e29)