### PR TITLE
Docs: Update confirmation behavior and roadmap (CLAUDE.md / AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,9 +165,7 @@ type Signal struct {
   - Creates file with channel label as filename
   - Registers OnMessage handler to write data chunks
   - Registers OnClose handler to finalize transfer
-- `askForConfirmation(s string, in io.Reader) bool` - User confirmation (currently hardcoded to return `true`)
-
-**IMPORTANT NOTE:** The confirmation function is currently bypassed (line 44 returns `true` immediately). The actual confirmation logic on lines 45-63 is unreachable.
+- `askForConfirmation(s string, in io.Reader) bool` - User confirmation prompt for incoming files.
 
 #### `datachannel_test.go` (19 lines)
 Skeleton tests (not implemented):
@@ -759,10 +757,9 @@ Transform HyperTunnel into the **easiest, most robust, and beautiful P2P file/di
 - `pkg/stun/` (new package) - Multi-server management
 
 #### 1.4 Security Enhancements
-- [ ] **Fix confirmation bypass bug**
-  - Remove `return true` hardcode in `askForConfirmation()`
-  - Implement actual user prompt before accepting files
-  - Add --auto-accept flag for automation
+- [ ] **Add auto-accept flag**
+  - Allow skipping the confirmation prompt for automation
+  - Keep prompting as the default behavior
 
 - [ ] **Improved key derivation**
   - Replace SHA256 with Argon2id KDF
@@ -780,7 +777,7 @@ Transform HyperTunnel into the **easiest, most robust, and beautiful P2P file/di
   - Add --overwrite flag for automation
 
 **Files to modify:**
-- `pkg/datachannel/handlers.go` - Fix confirmation & overwrite
+- `pkg/datachannel/handlers.go` - Add overwrite prompt + auto-accept flag
 - `pkg/hashutils/hashutils.go` - Implement Argon2id
 - `pkg/crypto/` (new package) - Signal authentication
 
@@ -1427,9 +1424,9 @@ package() {
 
 ### Critical Path (Start Here)
 
-1. **Fix existing bugs** (Phase 1.4 Security)
-   - Confirmation bypass
-   - File overwrite check
+1. **Harden incoming file handling** (Phase 1.4 Security)
+   - Add overwrite prompt/flag
+   - Add optional auto-accept flag
    - **Est:** 1 day
 
 2. **Add basic testing** (Phase 1.5)
@@ -1504,10 +1501,10 @@ When implementing features from this roadmap:
 6. **Use TodoWrite tool** - Track progress on multi-step features
 
 **Next immediate steps:**
-1. Fix confirmation bypass bug (`pkg/datachannel/handlers.go:44`)
-2. Fix file overwrite check (`pkg/datachannel/handlers.go:18-21`)
-3. Complete unit tests (`pkg/datachannel/datachannel_test.go`)
-4. Add progress tracking to file transfer
+1. Add overwrite prompt/flag (`pkg/datachannel/handlers.go`)
+2. Add progress tracking to file transfer
+3. Add directory transfer support
+4. Complete unit tests (`pkg/datachannel/datachannel_test.go`)
 5. Start Bubble Tea TUI implementation
 
 ---
@@ -1533,11 +1530,7 @@ When implementing features from this roadmap:
    - Impact: Dictionary attacks on weak passphrases
    - Improvement: Use PBKDF2, bcrypt, or Argon2
 
-4. **Confirmation Bypassed:** `askForConfirmation()` returns true (line 44 in handlers.go)
-   - Impact: Files auto-accepted without user consent
-   - Fix: Remove early return, enable actual user prompt
-
-5. **File Overwrite Risk:** Receiver doesn't check for existing files correctly
+4. **File Overwrite Risk:** Receiver doesn't check for existing files correctly
    - Line 18-21 in handlers.go: Uses `os.IsExist(err)` but `os.Stat()` returns `nil` error if file doesn't exist
    - Correct check: `!os.IsNotExist(err)` or `err == nil`
 
@@ -1713,7 +1706,7 @@ HyperTunnel is a focused, well-structured P2P file transfer tool with clear sepa
 **Areas for Improvement:**
 - Test coverage
 - File integrity verification
-- User confirmation implementation
+- File overwrite protection
 - Progress reporting
 
 **Philosophy:** Keep it simple. Don't over-engineer. Add features when clearly needed, not speculatively.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,9 +165,7 @@ type Signal struct {
   - Creates file with channel label as filename
   - Registers OnMessage handler to write data chunks
   - Registers OnClose handler to finalize transfer
-- `askForConfirmation(s string, in io.Reader) bool` - User confirmation (currently hardcoded to return `true`)
-
-**IMPORTANT NOTE:** The confirmation function is currently bypassed (line 44 returns `true` immediately). The actual confirmation logic on lines 45-63 is unreachable.
+- `askForConfirmation(s string, in io.Reader) bool` - User confirmation prompt for incoming files.
 
 #### `datachannel_test.go` (19 lines)
 Skeleton tests (not implemented):
@@ -759,10 +757,9 @@ Transform HyperTunnel into the **easiest, most robust, and beautiful P2P file/di
 - `pkg/stun/` (new package) - Multi-server management
 
 #### 1.4 Security Enhancements
-- [ ] **Fix confirmation bypass bug**
-  - Remove `return true` hardcode in `askForConfirmation()`
-  - Implement actual user prompt before accepting files
-  - Add --auto-accept flag for automation
+- [ ] **Add auto-accept flag**
+  - Allow skipping the confirmation prompt for automation
+  - Keep prompting as the default behavior
 
 - [ ] **Improved key derivation**
   - Replace SHA256 with Argon2id KDF
@@ -780,7 +777,7 @@ Transform HyperTunnel into the **easiest, most robust, and beautiful P2P file/di
   - Add --overwrite flag for automation
 
 **Files to modify:**
-- `pkg/datachannel/handlers.go` - Fix confirmation & overwrite
+- `pkg/datachannel/handlers.go` - Add overwrite prompt + auto-accept flag
 - `pkg/hashutils/hashutils.go` - Implement Argon2id
 - `pkg/crypto/` (new package) - Signal authentication
 
@@ -1427,9 +1424,9 @@ package() {
 
 ### Critical Path (Start Here)
 
-1. **Fix existing bugs** (Phase 1.4 Security)
-   - Confirmation bypass
-   - File overwrite check
+1. **Harden incoming file handling** (Phase 1.4 Security)
+   - Add overwrite prompt/flag
+   - Add optional auto-accept flag
    - **Est:** 1 day
 
 2. **Add basic testing** (Phase 1.5)
@@ -1504,10 +1501,10 @@ When implementing features from this roadmap:
 6. **Use TodoWrite tool** - Track progress on multi-step features
 
 **Next immediate steps:**
-1. Fix confirmation bypass bug (`pkg/datachannel/handlers.go:44`)
-2. Fix file overwrite check (`pkg/datachannel/handlers.go:18-21`)
-3. Complete unit tests (`pkg/datachannel/datachannel_test.go`)
-4. Add progress tracking to file transfer
+1. Add overwrite prompt/flag (`pkg/datachannel/handlers.go`)
+2. Add progress tracking to file transfer
+3. Add directory transfer support
+4. Complete unit tests (`pkg/datachannel/datachannel_test.go`)
 5. Start Bubble Tea TUI implementation
 
 ---
@@ -1533,11 +1530,7 @@ When implementing features from this roadmap:
    - Impact: Dictionary attacks on weak passphrases
    - Improvement: Use PBKDF2, bcrypt, or Argon2
 
-4. **Confirmation Bypassed:** `askForConfirmation()` returns true (line 44 in handlers.go)
-   - Impact: Files auto-accepted without user consent
-   - Fix: Remove early return, enable actual user prompt
-
-5. **File Overwrite Risk:** Receiver doesn't check for existing files correctly
+4. **File Overwrite Risk:** Receiver doesn't check for existing files correctly
    - Line 18-21 in handlers.go: Uses `os.IsExist(err)` but `os.Stat()` returns `nil` error if file doesn't exist
    - Correct check: `!os.IsNotExist(err)` or `err == nil`
 
@@ -1713,7 +1706,7 @@ HyperTunnel is a focused, well-structured P2P file transfer tool with clear sepa
 **Areas for Improvement:**
 - Test coverage
 - File integrity verification
-- User confirmation implementation
+- File overwrite protection
 - Progress reporting
 
 **Philosophy:** Keep it simple. Don't over-engineer. Add features when clearly needed, not speculatively.


### PR DESCRIPTION
### Motivation
- Remove an incorrect claim that `askForConfirmation` is hardcoded to `true` so docs reflect actual code behavior.
- Adjust the immediate roadmap to prioritize concrete remaining work (overwrite prompt/flag, progress reporting, directory transfer) instead of an already-fixed item.
- Keep the agent-focused documentation files in sync so contributors and automation see the same guidance.

### Description
- Edited `CLAUDE.md` and `AGENTS.md` to replace the obsolete note about `askForConfirmation` being bypassed with a correct description that it is a user prompt (`askForConfirmation`).
- Reworked the Security and Implementation Priority sections to remove the stale “confirmation bypass” entry, add an `auto-accept`/overwrite prompt focus, and reprioritize next immediate steps to: add overwrite prompt/flag, add progress tracking, add directory transfer support, complete unit tests, and start the TUI.
- Updated the “Files to modify” and “Areas for Improvement” entries to reference `pkg/datachannel/handlers.go` for overwrite handling and to emphasize file overwrite protection and progress reporting.
- Synchronized the same changes between `CLAUDE.md` and `AGENTS.md` so both docs remain consistent.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624c658f408331a543b359fc63acc4)