### PR TITLE
Add `--overwrite` flag to control incoming overwrite behavior

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ var (
 	isOffer    bool
 	file       string
 	autoAccept bool
+	overwrite  bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -73,7 +74,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.hypertunnel.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Increase verbosity")
 	rootCmd.Flags().StringVarP(&file, "file", "f", "", "File to transfer")
-	rootCmd.Flags().BoolVar(&autoAccept, "auto-accept", false, "Automatically accept incoming files and overwrites")
+	rootCmd.Flags().BoolVar(&autoAccept, "auto-accept", false, "Automatically accept incoming files")
+	rootCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing files or directories")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -101,6 +103,7 @@ func initConfig() {
 
 func Connection(cmd *cobra.Command, args []string) {
 	datachannel.AutoAccept = autoAccept
+	datachannel.OverwriteExisting = overwrite
 
 	// Who receiver and who sender?
 	var isDirectory bool

--- a/pkg/datachannel/handlers.go
+++ b/pkg/datachannel/handlers.go
@@ -31,12 +31,19 @@ func FileTransferHandler(channel *webrtc.DataChannel) {
 	// Check if target already exists
 	_, err := os.Stat(targetPath)
 	if err == nil {
-		if !AutoAccept {
+		if !OverwriteExisting {
 			overwrite := askForConfirmation(fmt.Sprintf("%s %s exists. Overwrite?",
 				map[bool]string{true: "Directory", false: "File"}[isArchive],
 				targetPath), os.Stdin)
 			if !overwrite {
 				fmt.Println("OK! Ignoring...")
+				return
+			}
+		}
+
+		if isArchive {
+			if err := os.RemoveAll(targetPath); err != nil {
+				log.Errorf("Failed to remove existing directory: %v", err)
 				return
 			}
 		}
@@ -138,6 +145,7 @@ func handleArchiveTransfer(channel *webrtc.DataChannel, targetPath string) {
 }
 
 var AutoAccept bool
+var OverwriteExisting bool
 
 func askForConfirmation(s string, in io.Reader) bool {
 	tries := 3


### PR DESCRIPTION
### Motivation
- Provide explicit control over whether incoming transfers overwrite existing files or directories to avoid accidental data loss.  
- Separate the semantics of `--auto-accept` (accept incoming transfers) from overwriting existing targets.  
- When receiving directory archives, ensure existing directories are removed before extraction when overwrite is permitted.  

### Description
- Add a new `--overwrite` root flag and variable in `cmd/root.go` and wire it to `datachannel.OverwriteExisting` at runtime.  
- Introduce `OverwriteExisting` in `pkg/datachannel/handlers.go` and use it to decide whether to prompt for overwrite or remove existing directories for archives.  
- Update receiver prompts so `--auto-accept` only controls acceptance of transfers and `--overwrite` controls whether existing targets are replaced.  
- Remove existing target directory with `os.RemoveAll` before extracting an incoming `.tar.gz` archive when overwrite is enabled.  

### Testing
- No automated tests were run for this change; please run `go test ./...` as needed to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b09c45708331a0114624e8e6f903)