### PR TITLE
Package binaries for multiple platforms with apt

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,6 @@ on:
 
 permissions:
   contents: write
-  # packages: write
-  # issues: write
-  # id-token: write
 
 jobs:
   goreleaser:
@@ -21,17 +18,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
-      # More assembly might be required: Docker logins, GPG, etc.
-      # It all depends on your needs.
+          go-version: '1.23'
+          cache: true
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: "~> v2"
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,16 @@ wip
 build
 bin
 Makefile
-ht*
-*txt
+dist
+
+# Binary files
+ht
+ht_*
+*.exe
+
+# Test files
+*.test
+
+# Log and temporary files
+*.log
+*.tmp

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,6 @@
 # .goreleaser.yml
+version: 2
+
 project_name: hypertunnel
 
 # Build configuration

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,363 @@
+# Installation Guide
+
+This guide provides detailed installation instructions for HyperTunnel across different platforms.
+
+## Table of Contents
+
+- [Linux](#linux)
+  - [Debian/Ubuntu (DEB)](#debianubuntu-deb)
+  - [Fedora/RHEL/CentOS (RPM)](#fedorarhel centos-rpm)
+  - [Alpine Linux (APK)](#alpine-linux-apk)
+  - [Arch Linux (AUR)](#arch-linux-aur)
+- [macOS](#macos)
+- [Windows](#windows)
+- [From Source](#from-source)
+- [Verification](#verification)
+
+---
+
+## Linux
+
+### Debian/Ubuntu (DEB)
+
+1. **Download the DEB package:**
+
+   Visit the [releases page](https://github.com/abrekhov/hypertunnel/releases) and download the appropriate `.deb` file for your architecture.
+
+   ```bash
+   # For AMD64 (most common)
+   wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel_VERSION_linux_amd64.deb
+
+   # For ARM64 (Raspberry Pi, Apple Silicon via Linux)
+   wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel_VERSION_linux_arm64.deb
+   ```
+
+2. **Install the package:**
+
+   ```bash
+   sudo apt install ./hypertunnel_VERSION_linux_amd64.deb
+   ```
+
+   Or using `dpkg`:
+
+   ```bash
+   sudo dpkg -i hypertunnel_VERSION_linux_amd64.deb
+   sudo apt-get install -f  # Install any missing dependencies
+   ```
+
+3. **Verify installation:**
+
+   ```bash
+   ht --version
+   # or
+   hypertunnel --version
+   ```
+
+### Fedora/RHEL/CentOS (RPM)
+
+1. **Download the RPM package:**
+
+   ```bash
+   # For AMD64
+   wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel-VERSION-amd64.rpm
+
+   # For ARM64
+   wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel-VERSION-arm64.rpm
+   ```
+
+2. **Install the package:**
+
+   **Fedora (dnf):**
+   ```bash
+   sudo dnf install ./hypertunnel-VERSION-amd64.rpm
+   ```
+
+   **RHEL/CentOS (yum):**
+   ```bash
+   sudo yum install ./hypertunnel-VERSION-amd64.rpm
+   ```
+
+   **openSUSE (zypper):**
+   ```bash
+   sudo zypper install ./hypertunnel-VERSION-amd64.rpm
+   ```
+
+3. **Verify installation:**
+
+   ```bash
+   ht --version
+   ```
+
+### Alpine Linux (APK)
+
+1. **Download the APK package:**
+
+   ```bash
+   wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel_VERSION_linux_amd64.apk
+   ```
+
+2. **Install the package:**
+
+   ```bash
+   sudo apk add --allow-untrusted ./hypertunnel_VERSION_linux_amd64.apk
+   ```
+
+3. **Verify installation:**
+
+   ```bash
+   ht --version
+   ```
+
+### Arch Linux (AUR)
+
+Coming soon! PKGBUILD will be published to the AUR.
+
+For now, use the generic Linux binary or build from source.
+
+---
+
+## macOS
+
+### Using Pre-built Binary
+
+1. **Download the archive:**
+
+   ```bash
+   # For Intel Macs (AMD64)
+   wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel_VERSION_darwin_amd64.tar.gz
+
+   # For Apple Silicon (ARM64)
+   wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel_VERSION_darwin_arm64.tar.gz
+   ```
+
+2. **Extract and install:**
+
+   ```bash
+   tar -xzf hypertunnel_VERSION_darwin_*.tar.gz
+   sudo mv ht /usr/local/bin/
+   sudo chmod +x /usr/local/bin/ht
+   ```
+
+3. **Verify installation:**
+
+   ```bash
+   ht --version
+   ```
+
+### Using Homebrew
+
+Coming soon! HyperTunnel will be available via Homebrew tap.
+
+Planned commands:
+```bash
+brew tap abrekhov/tap
+brew install hypertunnel
+```
+
+---
+
+## Windows
+
+### Using Pre-built Binary
+
+1. **Download the ZIP archive:**
+
+   Visit the [releases page](https://github.com/abrekhov/hypertunnel/releases) and download:
+
+   - `hypertunnel_VERSION_windows_amd64.zip` (64-bit)
+   - `hypertunnel_VERSION_windows_arm64.zip` (ARM64)
+
+2. **Extract the archive:**
+
+   Right-click the ZIP file and select "Extract All..."
+
+3. **Move the binary:**
+
+   Move `ht.exe` to a directory in your PATH, such as:
+   - `C:\Program Files\HyperTunnel\`
+   - `C:\Windows\System32\` (not recommended)
+   - Or add the extracted directory to your PATH
+
+4. **Add to PATH (optional):**
+
+   - Open "System Properties" → "Advanced" → "Environment Variables"
+   - Edit the "Path" variable
+   - Add the directory containing `ht.exe`
+
+5. **Verify installation:**
+
+   Open Command Prompt or PowerShell:
+   ```cmd
+   ht --version
+   ```
+
+### Using Package Managers
+
+**Scoop** (Coming soon):
+```powershell
+scoop bucket add abrekhov https://github.com/abrekhov/scoop-bucket
+scoop install hypertunnel
+```
+
+**Chocolatey** (Coming soon):
+```powershell
+choco install hypertunnel
+```
+
+---
+
+## From Source
+
+### Prerequisites
+
+- Go 1.23 or later
+- Git
+
+### Installation Steps
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/abrekhov/hypertunnel.git
+   cd hypertunnel
+   ```
+
+2. **Build the binary:**
+
+   ```bash
+   go build -o ht
+   ```
+
+3. **Install (optional):**
+
+   **Linux/macOS:**
+   ```bash
+   sudo mv ht /usr/local/bin/
+   ```
+
+   **Or use `go install`:**
+   ```bash
+   go install github.com/abrekhov/hypertunnel@latest
+   ```
+
+   Make sure `$GOBIN` or `$GOPATH/bin` is in your PATH:
+   ```bash
+   export PATH="$PATH:$(go env GOPATH)/bin"
+   ```
+
+4. **Verify installation:**
+
+   ```bash
+   ht --version
+   ```
+
+---
+
+## Verification
+
+### Checksum Verification
+
+To verify the integrity of downloaded packages:
+
+1. **Download checksums:**
+
+   ```bash
+   wget https://github.com/abrekhov/hypertunnel/releases/latest/download/checksums.txt
+   ```
+
+2. **Verify the package:**
+
+   **Linux/macOS:**
+   ```bash
+   sha256sum -c checksums.txt --ignore-missing
+   ```
+
+   **Windows (PowerShell):**
+   ```powershell
+   Get-FileHash hypertunnel_VERSION_windows_amd64.zip -Algorithm SHA256
+   # Compare with checksums.txt manually
+   ```
+
+### GPG Signature Verification
+
+*Currently, packages are not GPG-signed. This feature will be added in future releases.*
+
+---
+
+## Uninstallation
+
+### DEB (Debian/Ubuntu)
+```bash
+sudo apt remove hypertunnel
+```
+
+### RPM (Fedora/RHEL)
+```bash
+sudo dnf remove hypertunnel
+# or
+sudo yum remove hypertunnel
+```
+
+### APK (Alpine)
+```bash
+sudo apk del hypertunnel
+```
+
+### Manual Installation
+```bash
+sudo rm /usr/local/bin/ht
+sudo rm /usr/local/bin/hypertunnel  # If symlink exists
+```
+
+---
+
+## Troubleshooting
+
+### Command not found after installation
+
+**Linux/macOS:**
+- Verify PATH includes installation directory:
+  ```bash
+  echo $PATH
+  ```
+- Reload shell configuration:
+  ```bash
+  source ~/.bashrc  # or ~/.zshrc
+  ```
+
+**Windows:**
+- Close and reopen Command Prompt/PowerShell
+- Verify PATH environment variable
+
+### Permission denied
+
+**Linux/macOS:**
+```bash
+sudo chmod +x /usr/local/bin/ht
+```
+
+### DEB installation fails with dependencies
+
+```bash
+sudo apt-get install -f
+```
+
+### Connection issues during file transfer
+
+- Ensure both machines have internet access
+- Check firewall settings (may block STUN/TURN connections)
+- Try enabling verbose mode: `ht -v`
+
+---
+
+## Getting Help
+
+- **Documentation:** [README.md](README.md)
+- **Issues:** [GitHub Issues](https://github.com/abrekhov/hypertunnel/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/abrekhov/hypertunnel/discussions)
+
+---
+
+## Next Steps
+
+After installation, see the [Usage Guide](README.md#usage) to start transferring files!

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,0 +1,256 @@
+# Packaging and Distribution Guide
+
+This document explains how HyperTunnel is packaged and distributed across different platforms.
+
+## Overview
+
+HyperTunnel uses [GoReleaser](https://goreleaser.com/) with [nFPM](https://nfpm.goreleaser.com/) to create packages for multiple platforms and formats:
+
+- **DEB** packages (Debian, Ubuntu)
+- **RPM** packages (Fedora, RHEL, CentOS, openSUSE)
+- **APK** packages (Alpine Linux)
+- **Archives** (tar.gz for Linux/macOS, zip for Windows)
+
+## Build Process
+
+### Automated Releases
+
+Releases are automatically built when a new version tag is pushed:
+
+```bash
+# Create and push a new version tag
+git tag -a v1.0.0 -m "Release version 1.0.0"
+git push origin v1.0.0
+```
+
+This triggers the GitHub Actions workflow (`.github/workflows/release.yaml`) which:
+
+1. Checks out the repository
+2. Sets up Go environment
+3. Runs GoReleaser with the configuration from `.goreleaser.yaml`
+4. Creates packages for all platforms
+5. Uploads packages to GitHub Releases
+
+### Local Testing
+
+To test the packaging locally without creating a release:
+
+```bash
+# Install GoReleaser
+go install github.com/goreleaser/goreleaser@latest
+
+# Build packages without releasing
+goreleaser release --snapshot --clean
+
+# Output will be in the ./dist directory
+```
+
+## Package Details
+
+### Binary Name
+
+The main binary is named `ht` and is installed to:
+- **Linux/macOS**: `/usr/bin/ht`
+- **Windows**: User-defined location
+
+A symbolic link `hypertunnel` → `ht` is also created for convenience.
+
+### Package Contents
+
+All packages include:
+- `ht` binary
+- LICENSE file → `/usr/share/doc/hypertunnel/copyright`
+- README.md → `/usr/share/doc/hypertunnel/README.md`
+
+### Post-Installation Script
+
+The `scripts/postinstall.sh` script runs after installation and:
+- Creates a symbolic link `/usr/bin/hypertunnel` → `/usr/bin/ht`
+- Displays installation success message
+
+### Dependencies
+
+Packages depend on:
+- `ca-certificates` (for HTTPS connections to STUN/TURN servers)
+
+## Distribution Channels
+
+### GitHub Releases (Primary)
+
+All packages are published to GitHub Releases:
+- https://github.com/abrekhov/hypertunnel/releases
+
+Users can download packages directly from there.
+
+### Future Distribution Plans
+
+#### APT Repository (Launchpad PPA)
+
+To set up an official Ubuntu PPA:
+
+1. Create a Launchpad account
+2. Generate GPG key for package signing
+3. Create debian packaging files
+4. Upload to Launchpad
+
+Instructions: https://help.launchpad.net/Packaging/PPA
+
+#### Homebrew
+
+To add HyperTunnel to Homebrew:
+
+**Option 1: Personal Tap (Quick)**
+```bash
+# Create homebrew-tap repository
+# Add Formula/hypertunnel.rb
+
+# Users install with:
+brew tap abrekhov/tap
+brew install hypertunnel
+```
+
+**Option 2: Official Homebrew Core (Requires Review)**
+```bash
+# Fork homebrew-core
+# Add Formula/h/hypertunnel.rb
+# Submit PR
+```
+
+Update `.goreleaser.yaml` to automate Homebrew tap updates.
+
+#### Arch Linux AUR
+
+Create and publish PKGBUILD to AUR:
+1. Create PKGBUILD file
+2. Test with `makepkg -si`
+3. Push to AUR repository
+
+See: https://wiki.archlinux.org/title/AUR_submission_guidelines
+
+#### Windows Package Managers
+
+**Scoop:**
+- Create manifest in scoop bucket
+- Submit to scoop-extras
+
+**Chocolatey:**
+- Create .nuspec file
+- Submit to Chocolatey community feed
+
+## Version Management
+
+### Version Tagging Convention
+
+Use semantic versioning: `vMAJOR.MINOR.PATCH`
+
+Examples:
+- `v1.0.0` - First stable release
+- `v1.1.0` - New features added
+- `v1.1.1` - Bug fixes
+- `v2.0.0` - Breaking changes
+
+### Pre-release Versions
+
+For alpha/beta releases:
+- `v1.0.0-alpha.1`
+- `v1.0.0-beta.1`
+- `v1.0.0-rc.1`
+
+These will be marked as pre-releases on GitHub.
+
+## Package Naming
+
+### DEB/APK
+```
+hypertunnel_<VERSION>_<OS>_<ARCH>.deb
+hypertunnel_1.0.0_linux_amd64.deb
+```
+
+### RPM
+```
+hypertunnel-<VERSION>-<ARCH>.rpm
+hypertunnel-1.0.0-amd64.rpm
+```
+
+### Archives
+```
+hypertunnel_<VERSION>_<OS>_<ARCH>.tar.gz
+hypertunnel_1.0.0_linux_amd64.tar.gz
+hypertunnel_1.0.0_darwin_arm64.tar.gz
+hypertunnel_1.0.0_windows_amd64.zip
+```
+
+## Checksums
+
+A `checksums.txt` file is generated for all packages and binaries, containing SHA-256 hashes.
+
+Users can verify downloads:
+```bash
+sha256sum -c checksums.txt
+```
+
+## Signing Packages
+
+### Current State
+Packages are **not signed** yet.
+
+### Future: GPG Signing
+
+To sign DEB/RPM packages:
+
+1. Generate GPG key:
+   ```bash
+   gpg --gen-key
+   ```
+
+2. Export public key:
+   ```bash
+   gpg --armor --export your@email.com > public.key
+   ```
+
+3. Add to `.goreleaser.yaml`:
+   ```yaml
+   signs:
+     - artifacts: checksum
+       args:
+         - "--batch"
+         - "--local-user"
+         - "{{ .Env.GPG_FINGERPRINT }}"
+         - "--output"
+         - "${signature}"
+         - "--detach-sign"
+         - "${artifact}"
+   ```
+
+4. Set GPG_FINGERPRINT in GitHub secrets
+
+## Troubleshooting
+
+### Build Failures
+
+**Issue:** GoReleaser fails to build
+- Check Go version compatibility (requires Go 1.23+)
+- Verify `.goreleaser.yaml` syntax with `goreleaser check`
+
+**Issue:** Missing dependencies in package
+- Update `nfpms.dependencies` in `.goreleaser.yaml`
+
+### Installation Issues
+
+**DEB: Dependency errors**
+```bash
+sudo apt-get install -f
+```
+
+**RPM: Conflicts with existing files**
+```bash
+sudo rpm -e hypertunnel  # Remove old version first
+```
+
+## References
+
+- [GoReleaser Documentation](https://goreleaser.com/intro/)
+- [nFPM Documentation](https://nfpm.goreleaser.com/)
+- [Debian Package Guide](https://www.debian.org/doc/manuals/maint-guide/)
+- [RPM Packaging Guide](https://rpm-packaging-guide.github.io/)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)

--- a/README.md
+++ b/README.md
@@ -2,19 +2,72 @@
 
 ## Installation
 
+### Debian/Ubuntu (APT)
+
+Download the latest `.deb` package from the [releases page](https://github.com/abrekhov/hypertunnel/releases):
+
 ```bash
+# Download the latest .deb package
+wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel_VERSION_linux_amd64.deb
+
+# Install with apt
+sudo apt install ./hypertunnel_VERSION_linux_amd64.deb
+
+# Or use dpkg directly
+sudo dpkg -i hypertunnel_VERSION_linux_amd64.deb
+```
+
+### RPM-based Linux (Fedora, RHEL, CentOS)
+
+```bash
+# Download the latest .rpm package
+wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel-VERSION-amd64.rpm
+
+# Install with dnf/yum
+sudo dnf install ./hypertunnel-VERSION-amd64.rpm
+# or
+sudo yum install ./hypertunnel-VERSION-amd64.rpm
+```
+
+### Alpine Linux
+
+```bash
+# Download the latest .apk package
+wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel_VERSION_linux_amd64.apk
+
+# Install with apk
+sudo apk add --allow-untrusted ./hypertunnel_VERSION_linux_amd64.apk
+```
+
+### macOS / Linux (Archives)
+
+```bash
+# Download and extract the archive for your platform
+wget https://github.com/abrekhov/hypertunnel/releases/latest/download/hypertunnel_VERSION_OS_ARCH.tar.gz
+tar -xzf hypertunnel_VERSION_OS_ARCH.tar.gz
+sudo mv ht /usr/local/bin/
+```
+
+### Windows
+
+Download the `.zip` archive from the [releases page](https://github.com/abrekhov/hypertunnel/releases) and extract `ht.exe` to your desired location. Add it to your PATH for easy access.
+
+### From Source
+
+```bash
+# Clone the repository
 git clone https://github.com/abrekhov/hypertunnel
 cd hypertunnel
 go build -o ht
 ```
 
-Or using go install (GOBIN must be set)
+Or using go install (GOBIN must be set):
 
 ```bash
 export GOPATH=$HOME/go
 export GOBIN="${GOPATH}/bin"
 export PATH="$PATH:${GOPATH}/bin:${GOROOT}/bin"
-go install github.com/abrekhov/hypertunnel
+go install github.com/abrekhov/hypertunnel@latest
 ```
 
 ## Usage

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Post-installation script for HyperTunnel
+
+set -e
+
+# Create symbolic link for shorter command if it doesn't exist
+if [ ! -e /usr/bin/hypertunnel ] && [ -e /usr/bin/ht ]; then
+    ln -sf /usr/bin/ht /usr/bin/hypertunnel
+fi
+
+# Print installation success message
+echo "HyperTunnel has been successfully installed!"
+echo "Run 'ht --help' or 'hypertunnel --help' to get started."
+
+exit 0


### PR DESCRIPTION
This commit implements comprehensive packaging for all platforms via GoReleaser and nFPM, enabling easy installation through package managers.

Changes:
- Updated .goreleaser.yaml with nFPM configuration for DEB, RPM, and APK packages
- Added version 2 format for GoReleaser v2 compatibility
- Configured package metadata (vendor, maintainer, description, dependencies)
- Created binary archives for Linux, macOS, and Windows
- Added postinstall script to create 'hypertunnel' symlink

- Updated GitHub Actions workflow:
  - Specified Go 1.23 for consistency
  - Enabled build caching
  - Cleaned up permissions and comments

- Improved .gitignore:
  - Added 'dist' directory for GoReleaser output
  - Refined binary patterns to avoid excluding text files
  - Added test and log file patterns

- Enhanced README.md with installation instructions for:
  - Debian/Ubuntu (apt/dpkg)
  - Fedora/RHEL/CentOS (dnf/yum)
  - Alpine Linux (apk)
  - macOS/Linux (archives)
  - Windows (zip)
  - Source installation

- Added INSTALL.md:
  - Comprehensive installation guide for all platforms
  - Checksum verification instructions
  - Uninstallation steps
  - Troubleshooting section

- Added PACKAGING.md:
  - Documentation for maintainers
  - Build process explanation
  - Future distribution plans (Homebrew, AUR, Chocolatey)
  - Version management guidelines
  - Package signing roadmap

Packages will be automatically built and published to GitHub Releases when version tags (v*.*.*) are pushed.

Users can now install with:
  sudo apt install ./hypertunnel_VERSION_linux_amd64.deb
  sudo dnf install ./hypertunnel-VERSION-amd64.rpm
  sudo apk add --allow-untrusted ./hypertunnel_VERSION_linux_amd64.apk