### PR TITLE
Auto-accept incoming transfers after timeout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,15 +42,16 @@ import (
 
 // Flags
 var (
-	cfgFile    string
-	verbose    bool
-	isOffer    bool
-	file       string
-	autoAccept bool
-	noTUI      bool
-	useTUI     bool
-	autoCopy   bool
-	noCopy     bool
+	cfgFile       string
+	verbose       bool
+	isOffer       bool
+	file          string
+	autoAccept    bool
+	noTUI         bool
+	useTUI        bool
+	autoCopy      bool
+	noCopy        bool
+	autoAcceptTTL time.Duration
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -90,6 +91,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&useTUI, "tui", false, "Enable the terminal UI")
 	rootCmd.Flags().BoolVar(&autoCopy, "copy", true, "Automatically copy the connection signal when possible")
 	rootCmd.Flags().BoolVar(&noCopy, "no-copy", false, "Disable automatic signal copy")
+	rootCmd.Flags().DurationVar(&autoAcceptTTL, "accept-timeout", 20*time.Second, "Auto-accept incoming files after this timeout (0 disables)")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -158,6 +160,7 @@ func printTransferSummary(action string, total int64, progress *transfer.Progres
 // Connection handles the main WebRTC P2P connection logic for file transfer.
 func Connection(_ *cobra.Command, _ []string) {
 	datachannel.AutoAccept = autoAccept
+	datachannel.AcceptTimeout = autoAcceptTTL
 	if noCopy || !term.IsTerminal(int(os.Stdout.Fd())) {
 		autoCopy = false
 	}

--- a/pkg/datachannel/handlers_test.go
+++ b/pkg/datachannel/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,6 +63,12 @@ func TestAskForConfirmation(t *testing.T) {
 		input := strings.NewReader("\n")
 		result := askForConfirmation("Test question", input)
 		assert.True(t, result, "Should default to yes on empty input")
+	})
+
+	t.Run("returns true when timeout elapses", func(t *testing.T) {
+		input := strings.NewReader("")
+		result := askForConfirmationWithTimeout("Test question", input, 5*time.Millisecond)
+		assert.True(t, result, "Should auto-accept after timeout")
 	})
 
 	t.Run("returns false after 3 invalid attempts", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `--accept-timeout` to auto-accept incoming prompts after a timeout
- Default to 20s; set 0 to disable timeout behavior
- Keep existing auto-accept flag behavior intact