### PR TITLE
Add ht version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,9 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
+      - -X github.com/abrekhov/hypertunnel/cmd.Version={{.Version}}
+      - -X github.com/abrekhov/hypertunnel/cmd.Commit={{.Commit}}
+      - -X github.com/abrekhov/hypertunnel/cmd.Date={{.Date}}
 
 # Disable archiving
 archives:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -778,9 +778,8 @@ Transform HyperTunnel into the **easiest, most robust, and beautiful P2P file/di
   - Auto-reconnect with exponential backoff
 
 #### 1.3 Connection Improvements (IN PROGRESS)
-- [x] **Bi-directional candidate exchange** ✅
+- [ ] **Symmetric connection startup**
   - Allow starting in any order (remove offer/answer dependency)
-  - Implement symmetric connection setup
   - Both peers act as ICE controllers initially
 
 - [ ] **Multiple STUN/TURN servers** (FUTURE)
@@ -1554,7 +1553,7 @@ package() {
 - ✅ Multi-platform packages
 - ⏳ Homebrew/Scoop
 - ✅ Zero critical security issues
-- ✅ Symmetric connection (start in any order)
+- ⏳ Symmetric connection (start in any order)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -778,9 +778,8 @@ Transform HyperTunnel into the **easiest, most robust, and beautiful P2P file/di
   - Auto-reconnect with exponential backoff
 
 #### 1.3 Connection Improvements (IN PROGRESS)
-- [x] **Bi-directional candidate exchange** ✅
+- [ ] **Symmetric connection startup**
   - Allow starting in any order (remove offer/answer dependency)
-  - Implement symmetric connection setup
   - Both peers act as ICE controllers initially
 
 - [ ] **Multiple STUN/TURN servers** (FUTURE)
@@ -1553,7 +1552,7 @@ package() {
 - ✅ Multi-platform packages
 - ⏳ Homebrew/Scoop
 - ✅ Zero critical security issues
-- ✅ Symmetric connection (start in any order)
+- ⏳ Symmetric connection (start in any order)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,7 @@ sudo mv ht /usr/local/bin/
 
 ### Homebrew (macOS/Linux)
 
-```bash
-brew tap abrekhov/hypertunnel
-brew install hypertunnel
-```
+Planned. Homebrew tap is not published yet.
 
 ### Windows
 
@@ -155,6 +152,11 @@ Both computers must have access to the Internet!
 
 # Enable verbose logging
 ./ht -v -f <file-or-directory>
+
+# Print version
+./ht version
+# or
+./ht --version
 
 # Encrypt a file before transfer
 ./ht encrypt -k "your-passphrase" <file>

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,54 @@
+/*
+Copyright © 2021 Anton Brekhov <anton@abrekhov.ru>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// These variables are intended to be set at build time via -ldflags.
+// Defaults are useful for local `go build`.
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		long, _ := cmd.Flags().GetBool("long")
+		if !long {
+			fmt.Fprintln(cmd.OutOrStdout(), Version)
+			return
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "version\t%s\ncommit\t%s\ndate\t%s\n", Version, Commit, Date)
+	},
+}
+
+func init() {
+	// Keep `--version` output copy/paste friendly (one line).
+	rootCmd.Version = Version
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+
+	versionCmd.Flags().Bool("long", false, "Print extended version information")
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Adds a `ht version` subcommand and enables `--version` output (one-line, copy-friendly).\n\nAlso wires GoReleaser ldflags to stamp build metadata (version/commit/date) into the binary.\n\nDocs: mention version usage; keep AGENTS.md and CLAUDE.md in sync.