### PR TITLE
Fix Homebrew install for raw binary assets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,7 +60,9 @@ brews:
     description: P2P file transfer tool using WebRTC
     license: Apache-2.0
     install: |
-      bin.install "ht"
+      # Assets are published as raw binaries (e.g. ht_darwin_arm64).
+      # Install whichever one Homebrew downloaded, renaming it to `ht`.
+      bin.install Dir["ht_*"][0] => "ht"
     test: |
       system "#{bin}/ht", "--help"
 


### PR DESCRIPTION
## What
Fixes the Homebrew formula install step to work with GoReleaser's raw-binary artifacts (e.g. `ht_darwin_arm64`) by installing the downloaded `ht_*` file and renaming it to `ht`.

## Why
`bin.install \"ht\"` fails because the asset name in the release is not `ht`.

## Scope
- `.goreleaser.yaml` only